### PR TITLE
Track AMRAP reps and apply double training max increment for 10+ rep …

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -29,6 +29,14 @@ export async function initDatabase() {
       logger.info(`🔄 Loading database from ${dbPath}`);
       const buffer = fs.readFileSync(dbPath);
       db = new SQL.Database(buffer);
+      // Run migrations for existing databases
+      try {
+        db.run('ALTER TABLE program_lift_status ADD COLUMN amrap_reps INTEGER');
+        console.log('✅ Migration: added amrap_reps column to program_lift_status');
+        saveDatabase();
+      } catch (e) {
+        // Column already exists, ignore
+      }
     } else {
       console.log('🆕 Creating new database...');
       db = new SQL.Database();
@@ -210,6 +218,7 @@ function createTables() {
           cycle INTEGER NOT NULL,
           status TEXT CHECK(status IN ('completed', 'failed', 'skipped')) NOT NULL,
           notes TEXT,
+          amrap_reps INTEGER,
           updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
           FOREIGN KEY (program_id) REFERENCES programs(id) ON DELETE CASCADE,
           FOREIGN KEY (exercise_id) REFERENCES exercises(id),

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -591,11 +591,12 @@ export const programsAPI = {
    * @param {number} exerciseId - Exercise ID
    * @param {string} status - Status: 'completed', 'failed', or 'skipped'
    * @param {string} notes - Optional notes
+   * @param {number|null} amrapReps - Reps achieved on the AMRAP set (optional)
    */
-  setLiftStatus: async (programId, exerciseId, status, notes = null) => {
+  setLiftStatus: async (programId, exerciseId, status, notes = null, amrapReps = null) => {
     return await apiCall(`/programs/${programId}/lifts/${exerciseId}/status`, {
       method: 'PUT',
-      body: JSON.stringify({ status, notes }),
+      body: JSON.stringify({ status, notes, amrap_reps: amrapReps }),
     });
   },
 


### PR DESCRIPTION
…sets

When a user logs more than 10 reps on any AMRAP set during a 5/3/1 cycle, that lift's training max will increase by two cycles' worth (double increment) at the end of the cycle instead of the standard one-cycle increment.

- Add amrap_reps column to program_lift_status (with migration for existing DBs)
- Update setLiftStatus model method and API route to store AMRAP rep counts
- Update advanceWeek to detect >10 AMRAP reps and apply 2x increment
- Add AMRAP reps input field to StatusControls on weeks 1-3 (with live indicator)
- Update Week 4 training max preview to show double increment in blue when applicable
- Refresh allStatuses after each status update to keep the preview accurate

https://claude.ai/code/session_016mUFay2Kyp4aFzUE942Vu3