### PR TITLE
Use exercise_id as key instead of index in lifts list

### DIFF
--- a/frontend/src/pages/CurrentWeek.jsx
+++ b/frontend/src/pages/CurrentWeek.jsx
@@ -1003,8 +1003,8 @@ const CurrentWeek = () => {
         {/* Lifts */}
         <div className="space-y-6">
           {workout.lifts && workout.lifts.map((lift, liftIndex) => (
-            <div 
-              key={liftIndex} 
+            <div
+              key={lift.exercise_id}
               className={`bg-white border rounded-lg overflow-hidden transition-all ${getStatusBorderClass(lift.status)}`}
             >
               {/* Lift Header */}


### PR DESCRIPTION
## Summary
Updated the React key prop in the lifts mapping to use a stable identifier instead of the array index.

## Key Changes
- Changed the `key` prop from `liftIndex` to `lift.exercise_id` when rendering lift items
- This ensures each lift maintains its identity across re-renders, even if the list order changes

## Implementation Details
Using `exercise_id` as the key is more reliable than array indices because:
- It provides a stable, unique identifier for each lift
- Prevents issues with component state and animations when the list is reordered
- Follows React best practices for list rendering

https://claude.ai/code/session_019kTgrxFqZuEe5e9ZkhQ6VT