### PR TITLE
Fix AMRAP input focus loss by inlining StatusControls

### DIFF
--- a/frontend/src/pages/CurrentWeek.jsx
+++ b/frontend/src/pages/CurrentWeek.jsx
@@ -440,7 +440,12 @@ const CurrentWeek = () => {
    * Status control buttons component
    * Enhanced for mobile with better touch targets and spacing
    */
-  const StatusControls = ({ exerciseId, currentStatus, recordedAmrapReps }) => {
+  // NOTE: This is intentionally invoked as a regular function (not as a JSX
+  // component element) at the call site below. Defining a component inside the
+  // parent's render would give it a new identity on every render of
+  // CurrentWeek, causing React to unmount/remount the subtree on every
+  // keystroke — which makes the AMRAP <input> lose focus mid-typing.
+  const renderStatusControls = ({ exerciseId, currentStatus, recordedAmrapReps }) => {
     const isUpdating = updatingStatus.has(exerciseId);
     // AMRAP input is only relevant for 5/3/1 weeks 1-3 (weeks with an AMRAP set)
     const isAmrapWeek = workout && workout.program_type === '531' && workout.week >= 1 && workout.week <= 3;
@@ -1064,11 +1069,11 @@ const CurrentWeek = () => {
                   {/* Status Controls - hidden when collapsed */}
                   {!isLiftCollapsed(lift.exercise_id) && (
                     <div onClick={(e) => e.stopPropagation()}>
-                      <StatusControls
-                        exerciseId={lift.exercise_id}
-                        currentStatus={lift.status}
-                        recordedAmrapReps={lift.amrap_reps}
-                      />
+                      {renderStatusControls({
+                        exerciseId: lift.exercise_id,
+                        currentStatus: lift.status,
+                        recordedAmrapReps: lift.amrap_reps,
+                      })}
                     </div>
                   )}
 


### PR DESCRIPTION
## Summary

- Fixes the 5/3/1 AMRAP reps input losing focus after the first keystroke, so users can type multi-digit numbers (e.g. `12`) in one go.
- Root cause: `StatusControls` was defined **inside** `CurrentWeek`, giving it a new function identity on every parent render. When `setAmrapRepsInput` triggered a re-render, React saw a new component type at `<StatusControls />` and unmounted/remounted the subtree — destroying the `<input>` mid-keystroke.
- Fix: convert it from a JSX component element to a regular function call (`renderStatusControls({...})`) so its return value is reconciled inline as plain JSX. The `<input>` keeps a stable identity across renders and focus is preserved.

## Why the previous fix wasn't enough

AndreyRainchik/fitness-app#10 stabilized the lift container's `key` (`liftIndex` → `lift.exercise_id`). That's a correct fix in its own right, but the inner `StatusControls` was still being remounted because its component **type** identity — not its key — was changing on every render. This PR addresses that remaining root cause.

## Test plan

- [ ] Open a 5/3/1 workout in weeks 1–3 where an AMRAP set exists.
- [ ] Click into the "AMRAP reps achieved" input and type `12` — verify both digits land in the field without having to click back in.
- [ ] Type `15` to confirm the "2x increment next cycle!" badge still appears on week 3 when reps > 10.
- [ ] Click **Mark Complete** and confirm the entered reps are saved (badge / recorded reps render correctly).
- [ ] Click **Mark Failed** and **Clear** — verify all three status buttons still work.
- [ ] Collapse/expand a lift and confirm the controls still render and function correctly.

https://claude.ai/code/session_014nPHvauAErP5KM7BF8QUD5